### PR TITLE
transfer: Edgeware to Agile Content repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
 #Include EFP
 include(ExternalProject)
 ExternalProject_Add(project_efp
-        GIT_REPOSITORY https://github.com/Unit-X/efp.git
+        GIT_REPOSITORY https://github.com/agilecontent/efp.git
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp
         BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/efp
         GIT_PROGRESS 1

--- a/EFPBonding.cpp
+++ b/EFPBonding.cpp
@@ -1,7 +1,4 @@
-//
-// UnitX Edgeware AB 2020
-//
-
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #include "EFPBonding.h"
 #include "logger.h"
 

--- a/EFPBonding.h
+++ b/EFPBonding.h
@@ -1,6 +1,4 @@
-//
-// UnitX Edgeware AB 2020
-//
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 
 //Methods are NOT thread safe meaning you may only call all methods from the same thread as calling distributeDataGroup
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Edgeware AB
+Copyright (c) 2019-2020 Edgeware AB, Agile Content 2021-2022
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EFPBond
 
-The EFPBond is acting as a data distributor from [ElasticFrameProtocol](https://github.com/Unit-X/efp) and the underlying protocols.
+The EFPBond is acting as a data distributor from [ElasticFrameProtocol](https://github.com/agilecontent/efp) and the underlying protocols.
 
 ```
 ---------------------------------------------------------   /\
@@ -17,11 +17,11 @@ The EFPBond is acting as a data distributor from [ElasticFrameProtocol](https://
 
 ```
 
-The bonding plug-in makes it possible to use multiple interfaces to create a higher total trougput (bonding) and for protecting the data sending the same data over multiple interfaces (1+n).
+The bonding plug-in makes it possible to use multiple interfaces to create a higher total troughput (bonding) and for protecting the data sending the same data over multiple interfaces (1+n).
 
 You can for example send data over a mix of any UDP/SRT/TCP as illustrated above.
 
-Example 100% over a WIFI connection, then as backup 50% each over two 4G connections as backup. That would create a 1+1 protected signal bonding two 4G connections as backup to the primary WIFI connection.
+Example 100% over a WiFi connection, then as backup 50% each over two 4G connections as backup. That would create a 1+1 protected signal bonding two 4G connections as backup to the primary WIFI connection.
 
 Please read -> [**EFPBond**](https://edgeware-my.sharepoint.com/:p:/g/personal/anders_cedronius_edgeware_tv/Efpyixw-TG5KuUupbCKUgfgBM3zNs-_dhM5RbUBjgdrKpw?e=NcBUBW) for more information.
 
@@ -48,12 +48,12 @@ cmake -DCMAKE_BUILD_TYPE=Debug ..
 cmake --build . --config Debug
 ```
 
-Output: 
+Output:
 
 **efpbond.a**
 
-The static EFPBond library 
- 
+The static EFPBond library
+
 **efpbondtest**
 
 *efpbondtest* (executable) runs trough the unit tests and returns EXIT_SUCESS if all unit tests pass.
@@ -100,7 +100,7 @@ EFPBonding::EFPBondingGroupID bondingGroupID = myEFPBonding.addInterfaceGroup(lI
 
 **Step 4**
 
-Pass fragment to all groups and all interfaces by sending the EFP fragments troug the bonding plug-in.
+Pass fragment to all groups and all interfaces by sending the EFP fragments trough the bonding plug-in.
 
 ```
 void sendData(const std::vector<uint8_t> &rSubPacket, uint8_t fragmentID) {
@@ -108,7 +108,7 @@ void sendData(const std::vector<uint8_t> &rSubPacket, uint8_t fragmentID) {
 }
 
 ```
-If split-mode is used 
+If split-mode is used
 
 ```
 EFPBondingMessages result = myEFPBonding.splitData(rSubPacket, fragmentID);
@@ -153,21 +153,18 @@ Please see examples in ElasticFrameProrocol repository and the CMakeLists.txt in
 
 ## History
 
-When using multiple interfaces to either load balance between the interfaces or when securing your transport using 1 + n you have traditionally been bound to that transport protocols features.  EFPBond decouples the transport protocol from those features and allows you to select any underlying transport protocol still being able to protect and load balance between multiple transport interfaces and /or transport technologies. 
+When using multiple interfaces to either load balance between the interfaces or when securing your transport using 1 + n you have traditionally been bound to that transport protocols features.  EFPBond decouples the transport protocol from those features and allows you to select any underlying transport protocol still being able to protect and load balance between multiple transport interfaces and /or transport technologies.
 
-If you for example use WIFI to transport your media from a location but need 4G as backup. The 4G connection might not support the bandwidth and is also delaying the signal from your remote location to the receiver, since you added more delay on the 4G connection to cater for more re-transmissions if using a ARQ based underlying protocol. Then EFPBond can help you send 100% over your WIFI and spread another (1+1) 100% of the payload over for example two 4G connections. 
+If you for example use WiFi to transport your media from a location but need 4G as backup. The 4G connection might not support the bandwidth and is also delaying the signal from your remote location to the receiver, since you added more delay on the 4G connection to cater for more re-transmissions if using a ARQ based underlying protocol. Then EFPBond can help you send 100% over your WiFi and spread another (1+1) 100% of the payload over for example two 4G connections.
 
 
 ## Credits
 
-The UnitX team at Edgeware AB
-
-Maintainer: anders.cedronius(at)edgeware.tv
-
+The UnitX team at Edgeware AB. Edgeware is part of Agile Content from 2021.
 
 
 ## License
 
 *MIT*
 
-Read *LICENCE.md* for details
+Read *LICENSE.md* for details

--- a/logger.h
+++ b/logger.h
@@ -1,7 +1,4 @@
-//
-// UnitX Edgeware AB 2020
-//
-
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #ifndef LOGGER_H
 #define LOGGER_H
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+// Copyright Edgeware AB 2020, Agile Content 2021-2022
 #include <iostream>
 #include "efp/ElasticFrameProtocol.h"
 #include "EFPBonding.h"


### PR DESCRIPTION
Change of repo ownership: unit-x -> agilecontent
This is part of a major change of ownership for all public efp repos